### PR TITLE
Implemented a version check for the Flowee backend

### DIFF
--- a/lib/bitpal/backends/flowee/flowee.ex
+++ b/lib/bitpal/backends/flowee/flowee.ex
@@ -279,8 +279,13 @@ defmodule BitPal.Backend.Flowee do
         {minor, _} = Integer.parse(minor)
 
         if major < @flowee_min_major or
-        (major == @flowee_min_major and minor < @flowee_min_minor) do
-          Logger.error("Your version of Flowee is too old. You have #{major}-#{minor}, we require #{@flowee_min_major}-#{@flowee_min_minor} or later.")
+             (major == @flowee_min_major and minor < @flowee_min_minor) do
+          Logger.error(
+            "Your version of Flowee is too old. You have #{major}-#{minor}, we require #{
+              @flowee_min_major
+            }-#{@flowee_min_minor} or later."
+          )
+
           raise "incompatible flowee version"
         end
 

--- a/test/backends/flowee/flowee_test.exs
+++ b/test/backends/flowee/flowee_test.exs
@@ -13,6 +13,7 @@ defmodule BitPal.Backend.FloweeTest do
   setup tags do
     init_mock(@client)
 
+    MockTCPClient.response(@client, FloweeFixtures.version_msg())
     MockTCPClient.response(@client, FloweeFixtures.blockchain_info())
 
     start_supervised!(

--- a/test/fixtures/flowee.ex
+++ b/test/fixtures/flowee.ex
@@ -27,6 +27,15 @@ defmodule BitPal.Backend.FloweeFixtures do
     ]
   end
 
+  def version_msg do
+    # Version: Flowee: 1 (2021-05) (note: this version might not actually exist).
+    [
+      <<27, 0>>,
+      <<8, 0, 16, 1, 4, 10, 18, 70, 108, 111, 119, 101, 101, 58, 49, 32, 40, 50, 48, 50, 49, 45,
+        48, 53, 41>>
+    ]
+  end
+
   def blockchain_info do
     # blocks: 690637,
     # chain: "main",


### PR DESCRIPTION
These commits verify that the version of Flowee that we are connected to is recent enough to include a TxId in the queries we are looking for. For this, we will require version 2021-05 or later of The Hub.

Note: This version is not released with its own version number yet, so it is possible that version 2021-05 will not exist. Regardless, the current check will still be correct.

Anyway, since a version of Flowee is not yet released, we should not merge this PR until that happens. Otherwise the version check will always fail.