### PR TITLE
Fixed the parsing of double spend proof reception in Flowee.

### DIFF
--- a/lib/bitpal/backends/flowee/protocol.ex
+++ b/lib/bitpal/backends/flowee/protocol.ex
@@ -309,11 +309,7 @@ defmodule BitPal.Backend.Flowee.Protocol do
 
       {@service_addressmonitor, 4} ->
         # Sent when a double-spend is found.
-        make_msg_opt(
-          :on_double_spend,
-          [txid: 4, address: 9, amount: 6, transaction: 1],
-          body
-        )
+        %Message{type: :on_transaction, data: parse_on_transaction(body)}
 
       {@service_indexer, 1} ->
         # Indexer reply to what it is indexing.


### PR DESCRIPTION
This is not tested, but it is the same code as the "normal" case. Flowee seems
to send the same type of messages for both notifications, so it should work.

Even though this is not tested throughoutly yet, I want to merge it now, so that the API is "right" before we start using it somewhere else.