### PR TITLE
Added foundations for how to verify that Flowee is not ready yet.

### DIFF
--- a/lib/bitpal/backends/flowee/flowee.ex
+++ b/lib/bitpal/backends/flowee/flowee.ex
@@ -141,9 +141,14 @@ defmodule BitPal.Backend.Flowee do
   end
 
   # Called when we received information from the blockchain.
-  defp on_info(%{blocks: height}) do
+  defp on_info(%{blocks: height, verification_progress: progress}) do
     Logger.info("Startup: new block height: #{inspect(height)}")
     Blocks.set_block_height(@bch, height)
+
+    if progress < 0.9999 do
+      # Note: We have a mock "blockchain_verifying_info" that generates this error.
+      Logger.warning("Startup: Flowee has not yet verified the blockchain.")
+    end
   end
 
   # Called when a new block has been mined (regardless of whether or not it contains one of our transactions)

--- a/test/fixtures/flowee.ex
+++ b/test/fixtures/flowee.ex
@@ -43,6 +43,23 @@ defmodule BitPal.Backend.FloweeFixtures do
     ]
   end
 
+  def blockchain_verifying_info do
+    # This is captured when Flowee was just started, and have not yet had time to download
+    # the blockchain. This can be seen by the "verification_progress".
+    # blocks: 7246
+    # chain: "main"
+    # verification_progress: 2.1309...e-5
+    [
+      <<120, 0>>,
+      <<8, 1, 16, 1, 4, 250, 67, 4, 109, 97, 105, 110, 248, 68, 183, 78, 248, 69, 157, 152, 121,
+        251, 70, 32, 10, 53, 213, 74, 198, 114, 43, 25, 36, 209, 80, 186, 86, 65, 88, 110, 178,
+        60, 79, 227, 160, 76, 155, 168, 143, 251, 35, 38, 0, 0, 0, 0, 254, 64, 0, 0, 0, 0, 0, 0,
+        240, 63, 248, 65, 131, 204, 229, 168, 117, 254, 71, 220, 179, 74, 219, 49, 249, 246, 62,
+        251, 66, 32, 78, 28, 78, 28, 78, 28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0>>
+    ]
+  end
+
   def new_block do
     # height: 690638
     [


### PR DESCRIPTION
This is the first step to solve issue #7.

It turns out that the `verification_progress` inside the `blockchain_info` message can be used to see the status of Flowee. In this commit, I have only added minimal code to identify the issue in the initialization code for Flowee, but I don't do anything with it.

I also added a fixture (as noted in the code) where I started Flowee from a clean slate. There, we get a verification progress close to zero quite quickly. If we do get one of those messages, the Flowee backend should inform the rest of the system that it is not ready yet, and the backend should periodically poll Flowee for its status until it is ready. We can still subscribe for it to tell us when it receives new blocks, so one way of doing this would be to ask for status on every 5th or 10th block or so.