### PR TITLE
Send authentication token over x-headers

### DIFF
--- a/lib/bitpal_api/endpoint.ex
+++ b/lib/bitpal_api/endpoint.ex
@@ -11,7 +11,7 @@ defmodule BitPalApi.Endpoint do
   ]
 
   socket("/socket", BitPalApi.StoreSocket,
-    websocket: true,
+    websocket: [connect_info: [:x_headers]],
     longpoll: false
   )
 

--- a/test/bitpal_api/authentication/socket_auth_test.exs
+++ b/test/bitpal_api/authentication/socket_auth_test.exs
@@ -3,7 +3,9 @@ defmodule BitPalApi.SocketAuthTest do
 
   test "successful auth" do
     %{store_id: _store_id, token: token} = create_auth()
-    {:ok, _socket} = connect(BitPalApi.StoreSocket, %{"token" => token})
+
+    {:ok, _socket} =
+      connect(BitPalApi.StoreSocket, %{}, %{x_headers: [{"x-access-token", token}]})
   end
 
   test "no auth" do


### PR DESCRIPTION
The standard way, as uri params and recommended by the Phoenix docs,
is vulnerable to man-in-the-middle attacks.