### PR TITLE
Add back token auth

### DIFF
--- a/lib/bitpal_api/channels/store_socket.ex
+++ b/lib/bitpal_api/channels/store_socket.ex
@@ -7,6 +7,17 @@ defmodule BitPalApi.StoreSocket do
   channel("exchange_rate:*", BitPalApi.ExchangeRateChannel)
 
   @impl true
+  def connect(%{"token" => token}, socket, _connect_info) do
+    case Tokens.authenticate_token(token) do
+      {:ok, store_id} ->
+        {:ok, assign(socket, :store_id, store_id)}
+
+      _ ->
+        :error
+    end
+  end
+
+  @impl true
   def connect(_params, socket, %{x_headers: x_headers}) do
     with {:ok, token} <- find_token(x_headers),
          {:ok, store_id} <- Tokens.authenticate_token(token) do

--- a/test/bitpal_api/authentication/socket_auth_test.exs
+++ b/test/bitpal_api/authentication/socket_auth_test.exs
@@ -1,18 +1,28 @@
 defmodule BitPalApi.SocketAuthTest do
   use BitPalApi.ChannelCase
 
-  test "successful auth" do
+  test "successful auth with headers" do
     %{store_id: _store_id, token: token} = create_auth()
 
     {:ok, _socket} =
       connect(BitPalApi.StoreSocket, %{}, %{x_headers: [{"x-access-token", token}]})
   end
 
+  test "successful auth with params" do
+    %{store_id: _store_id, token: token} = create_auth()
+
+    {:ok, _socket} = connect(BitPalApi.StoreSocket, %{"token" => token}, %{})
+  end
+
   test "no auth" do
     :error = connect(BitPalApi.StoreSocket, %{})
   end
 
-  test "bad auth" do
+  test "bad auth with headers" do
     :error = connect(BitPalApi.StoreSocket, %{"token" => "bad-token"})
+  end
+
+  test "bad auth with params" do
+    :error = connect(BitPalApi.StoreSocket, %{}, %{x_headers: [{"x-access-token", "bad-token"}]})
   end
 end


### PR DESCRIPTION
No big difference with auth over params/headers, you should be
using TLS anyway. Support both instead.